### PR TITLE
Fix social media and blog link paths

### DIFF
--- a/themes/asg/layouts/404.html
+++ b/themes/asg/layouts/404.html
@@ -9,7 +9,7 @@
           </p>
         </div>
         <div class="post-preview">
-            <p class="post-meta"><a href="{{ .Site.BaseURL }}/blog/">All Systems Go! blog</a>
+            <p class="post-meta"><a href="{{ .Site.BaseURL }}/all-systems-go.io/blog/">All Systems Go! blog</a>
             </p>
         </div>
       </div>

--- a/themes/asg/layouts/partials/featured-speaker.html
+++ b/themes/asg/layouts/partials/featured-speaker.html
@@ -18,10 +18,10 @@
    </div>
    <div class="card-footer text-right">
          {{ with $spkr.twitter }}
-          <a class="fab fa-twitter fa-2x mx-2" href="https:/twitter.com/{{ . }}"></a>
+          <a class="fab fa-twitter fa-2x mx-2" href="https://twitter.com/{{ . }}"></a>
          {{ end }}
          {{ with $spkr.github }}
-         <a class="fab fa-github fa-2x mx-1" href="https:/github.com/{{ . }}"></a>
+         <a class="fab fa-github fa-2x mx-1" href="https://github.com/{{ . }}"></a>
          {{ end }}
    </div>
 </div>


### PR DESCRIPTION
Currently, the speakers' twitter and github links are incorrect. For example, Alban Crequy's twitter link leads to https://all-systems-go.io/twitter.com/alban and github link leads to https://all-systems-go.io/github.com/albcr.

On the 404 page, the blog link leads to https://blog/.

This PR fixes both the links.

/cc @blixtra