### PR TITLE
Provide a link to company websites

### DIFF
--- a/themes/asg/layouts/index.html
+++ b/themes/asg/layouts/index.html
@@ -70,7 +70,7 @@
             <img class="speakers__background" src="/images/icons/arrows-speakers.svg" alt="">
             <p class="speakers__name">{{ .name }}</p>
             <div class="speakers__company">
-              <span>{{ .company }}:</span>
+              <span><a href="{{ .company_link }}">{{ .company }}</a></span>
               <span>{{ .projects }}</span>
             </div>
           </div>


### PR DESCRIPTION
There was a hanging ":" where the company link should be. This commit fixes that by turning the company name into a link to the company website.